### PR TITLE
feat: CRUD de funcionários

### DIFF
--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -4,9 +4,4 @@ import { AppService } from './app.service';
 @Controller()
 export class AppController {
   constructor(private readonly appService: AppService) {}
-
-  @Get()
-  getHello(): string {
-    return this.appService.getHello();
-  }
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { ClienteModule } from './cliente/cliente.module';
+import { FuncionarioModule } from './funcionario/funcionario.module';
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { ClienteModule } from './cliente/cliente.module';
       synchronize: true
     }),
     ClienteModule,
+    FuncionarioModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -1,8 +1,4 @@
 import { Injectable } from '@nestjs/common';
 
 @Injectable()
-export class AppService {
-  getHello(): string {
-    return 'Hello World!';
-  }
-}
+export class AppService {}

--- a/src/funcionario/dto/create-funcionario.dto.ts
+++ b/src/funcionario/dto/create-funcionario.dto.ts
@@ -1,0 +1,12 @@
+import { IsEmail, IsNotEmpty, MinLength } from 'class-validator';
+
+export class CreateFuncionarioDto {
+  @IsNotEmpty()
+  nome: string;
+
+  @IsEmail()
+  email: string;
+
+  @MinLength(6)
+  senha: string;
+}

--- a/src/funcionario/funcionario.controller.spec.ts
+++ b/src/funcionario/funcionario.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { FuncionarioController } from './funcionario.controller';
+
+describe('FuncionarioController', () => {
+  let controller: FuncionarioController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [FuncionarioController],
+    }).compile();
+
+    controller = module.get<FuncionarioController>(FuncionarioController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/funcionario/funcionario.controller.ts
+++ b/src/funcionario/funcionario.controller.ts
@@ -1,0 +1,33 @@
+import { Controller, Post, Get, Put, Delete, Body, Param } from '@nestjs/common';
+import { FuncionarioService } from './funcionario.service';
+import { CreateFuncionarioDto } from './dto/create-funcionario.dto';
+
+@Controller('funcionarios')
+export class FuncionarioController {
+  constructor(private readonly funcionarioService: FuncionarioService) {}
+
+  @Post()
+  create(@Body() data: CreateFuncionarioDto) {
+    return this.funcionarioService.create(data);
+  }
+
+  @Get()
+  findAll() {
+    return this.funcionarioService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.funcionarioService.findOne(+id);
+  }
+
+  @Put(':id')
+  update(@Param('id') id: string, @Body() data: Partial<CreateFuncionarioDto>) {
+    return this.funcionarioService.update(+id, data);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.funcionarioService.remove(+id);
+  }
+}

--- a/src/funcionario/funcionario.entity.ts
+++ b/src/funcionario/funcionario.entity.ts
@@ -1,0 +1,19 @@
+import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn } from 'typeorm';
+
+@Entity()
+export class Funcionario {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  nome: string;
+
+  @Column({ unique: true })
+  email: string;
+
+  @Column()
+  senha: string;
+
+  @CreateDateColumn({ type: 'timestamp' })
+  dataCriacao: Date;
+}

--- a/src/funcionario/funcionario.module.ts
+++ b/src/funcionario/funcionario.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Funcionario } from './funcionario.entity';
+import { FuncionarioController } from './funcionario.controller';
+import { FuncionarioService } from './funcionario.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Funcionario])],
+  controllers: [FuncionarioController],
+  providers: [FuncionarioService],
+})
+export class FuncionarioModule {}

--- a/src/funcionario/funcionario.service.spec.ts
+++ b/src/funcionario/funcionario.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { FuncionarioService } from './funcionario.service';
+
+describe('FuncionarioService', () => {
+  let service: FuncionarioService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [FuncionarioService],
+    }).compile();
+
+    service = module.get<FuncionarioService>(FuncionarioService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/funcionario/funcionario.service.ts
+++ b/src/funcionario/funcionario.service.ts
@@ -1,0 +1,46 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Funcionario } from './funcionario.entity';
+import { CreateFuncionarioDto } from './dto/create-funcionario.dto';
+
+@Injectable()
+export class FuncionarioService {
+  constructor(
+    @InjectRepository(Funcionario)
+    private readonly funcionarioRepo: Repository<Funcionario>,
+  ) {}
+
+  async create(data: CreateFuncionarioDto): Promise<Funcionario> {
+    const funcionario = this.funcionarioRepo.create(data);
+    return this.funcionarioRepo.save(funcionario);
+  }
+
+  async findAll(): Promise<Funcionario[]> {
+    return this.funcionarioRepo.find();
+  }
+
+  async findOne(id: number): Promise<Funcionario> {
+    const funcionario = await this.funcionarioRepo.findOne({ where: { id } });
+    if (!funcionario) {
+      throw new NotFoundException(`Funcionário com ID ${id} não encontrado`);
+    }
+    return funcionario;
+  }
+
+  async update(id: number, data: Partial<CreateFuncionarioDto>): Promise<Funcionario> {
+    await this.funcionarioRepo.update(id, data);
+    const updated = await this.funcionarioRepo.findOne({ where: { id } });
+    if (!updated) {
+      throw new NotFoundException(`Funcionário com ID ${id} não encontrado`);
+    }
+    return updated;
+  }
+
+  async remove(id: number): Promise<void> {
+    const result = await this.funcionarioRepo.delete(id);
+    if (result.affected === 0) {
+      throw new NotFoundException(`Funcionário com ID ${id} não encontrado`);
+    }
+  }
+}


### PR DESCRIPTION
## feat: CRUD de funcionários
- Cria entidade Funcionario com campos nome, email, senha, data de criação
- Implementa DTO com validações
- Adiciona controller e service com rotas POST, GET, PUT, DELETE
- Relacionado ao teste técnico de CRUD para loja
